### PR TITLE
Add KeyValueExtraSpaceRule

### DIFF
--- a/Sources/L10nLintFramework/Models/EmbeddedRules.swift
+++ b/Sources/L10nLintFramework/Models/EmbeddedRules.swift
@@ -7,7 +7,8 @@ public class EmbeddedRules {
         EmptyValueRule.self,
         EmptyKeyRule.self,
         MultiLinefeedRule.self,
-        SpaceInKeyRule.self
+        SpaceInKeyRule.self,
+        KeyValueExtraSpaceRule.self
     ]
 
     public static let defaultEnabledRules: [Rule.Type] = [
@@ -18,6 +19,7 @@ public class EmbeddedRules {
         EmptyValueRule.self,
         EmptyKeyRule.self,
         MultiLinefeedRule.self,
-        SpaceInKeyRule.self
+        SpaceInKeyRule.self,
+        KeyValueExtraSpaceRule.self
     ]
 }

--- a/Sources/L10nLintFramework/Rules/KeyValueExtraSpaceRule.swift
+++ b/Sources/L10nLintFramework/Rules/KeyValueExtraSpaceRule.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct KeyValueExtraSpaceRule: Rule {
+    static let description: RuleDescription = .init(identifier: "key_value_extra_space", name: "Key value extra space", description: "Key value should be correct spacing.")
+
+    init() {}
+
+    func validate(baseProject: LocalizedProject, project: LocalizedProject) throws -> [StyleViolation] {
+        let keyValueMatchesRegex = try NSRegularExpression(pattern: #"^ *".*" *= *".*" *; *$"#, options: .anchorsMatchLines)
+        let correctKeyValueRegex = try NSRegularExpression(pattern: #"^".*" = ".*";$"#, options: .anchorsMatchLines)
+
+        let projectContents = project.stringsFile.contents
+        return keyValueMatchesRegex.matches(in: projectContents).compactMap { result in
+            guard let range = Range(result.range(at: 0), in: projectContents) else { return nil }
+            let line = String(projectContents[range])
+            guard correctKeyValueRegex.firstMatch(in: line) == nil else { return nil }
+            return StyleViolation(
+                ruleDescription: Self.description,
+                severity: .warning,
+                location: Location(file: project.stringsFile, characterOffset: result.range.location)
+            )
+        }
+    }
+}

--- a/Tests/L10nLintFrameworkTests/Resources/Fixtures/Localizables5/Base.lproj/Localizable.strings
+++ b/Tests/L10nLintFrameworkTests/Resources/Fixtures/Localizables5/Base.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+// MARK: KeyValueExtraSpaceRule
+"Key" = "Value";
+ "Key" = "Value";
+"Key"  = "Value";
+"Key" =  "Value";
+"Key" = "Value" ;
+"Key" = "Value";

--- a/Tests/L10nLintFrameworkTests/RulesTests.swift
+++ b/Tests/L10nLintFrameworkTests/RulesTests.swift
@@ -117,6 +117,21 @@ final class RulesTests: XCTestCase {
             ]
         )
     }
+
+    func testKeyValueExtraSpaceRule() throws {
+        let baseProject = try TestHelper.localizedProjects(fixtureName: "Localizables5")
+            .first(where: { $0.name == "Base" })!
+        let violations = try KeyValueExtraSpaceRule().validate(baseProject: baseProject, project: baseProject)
+        XCTAssertEqual(
+            violations.map(\.location.point),
+            [
+                LocationPoint(line: 3, character: 1),
+                LocationPoint(line: 4, character: 1),
+                LocationPoint(line: 5, character: 1),
+                LocationPoint(line: 6, character: 1)
+            ]
+        )
+    }
 }
 
 extension Location {


### PR DESCRIPTION
Key value line should not have extra space.

```
"Correct" = "Value";
 "Not correct"  =  "Value" ;
```