### PR TITLE
Add format specifier rules

### DIFF
--- a/Sources/L10nLintFramework/Models/EmbeddedRules.swift
+++ b/Sources/L10nLintFramework/Models/EmbeddedRules.swift
@@ -9,7 +9,9 @@ public class EmbeddedRules {
         MultiLinefeedRule.self,
         SpaceInKeyRule.self,
         KeyValueExtraSpaceRule.self,
-        MixedChineseRule.self
+        MixedChineseRule.self,
+        IntegerFormatSpecifierRule.self,
+        KeyValueFormatSpecifierCountRule.self
     ]
 
     public static let defaultEnabledRules: [Rule.Type] = [
@@ -22,6 +24,8 @@ public class EmbeddedRules {
         MultiLinefeedRule.self,
         SpaceInKeyRule.self,
         KeyValueExtraSpaceRule.self,
-        MixedChineseRule.self
+        MixedChineseRule.self,
+        IntegerFormatSpecifierRule.self,
+        KeyValueFormatSpecifierCountRule.self
     ]
 }

--- a/Sources/L10nLintFramework/Rules/IntegerFormatSpecifierRule.swift
+++ b/Sources/L10nLintFramework/Rules/IntegerFormatSpecifierRule.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct IntegerFormatSpecifierRule: Rule {
+    static let description: RuleDescription = .init(identifier: "integer_format_specifier", name: "Integer Format Specifier", description: "Integer format specifier should be '%lld' instead of '%d'")
+
+    init() {}
+
+    func validate(baseProject: LocalizedProject, project: LocalizedProject) throws -> [StyleViolation] {
+        let regex = try NSRegularExpression(pattern: #"^.*(?<specifier>%[0-9]*d).*$"#, options: .anchorsMatchLines)
+
+        return regex.matches(in: project.stringsFile.contents).map { result in
+            StyleViolation(
+                ruleDescription: Self.description,
+                severity: .warning,
+                location: Location(file: project.stringsFile, characterOffset: result.range(withName: "specifier").location)
+            )
+        }
+    }
+}
+

--- a/Sources/L10nLintFramework/Rules/KeyValueFormatSpecifierCountRule.swift
+++ b/Sources/L10nLintFramework/Rules/KeyValueFormatSpecifierCountRule.swift
@@ -7,7 +7,7 @@ struct KeyValueFormatSpecifierCountRule: Rule {
 
     func validate(baseProject: LocalizedProject, project: LocalizedProject) throws -> [StyleViolation] {
         let keyValueRegex = try NSRegularExpression(pattern: #"^ *"(?<key>.*)" *= *"(?<value>.*)" *; *$"#, options: .anchorsMatchLines)
-        let formatSpecifierRegex = try NSRegularExpression(pattern: #"%[0-9]*(?<type>[@dDuUxXoOfFeEgGcCsSpaAhlqLztj]+)"#)
+        let formatSpecifierRegex = try NSRegularExpression(pattern: #"%[0-9]*(?<type>([@cCsSp]|(([hlqztj]|ll)?[dDuUxXoO])|(L?[aAeEfFg])))"#)
 
         return keyValueRegex.matches(in: project.stringsFile.contents).compactMap { result in
             let nsStringContents = project.stringsFile.contents as NSString

--- a/Sources/L10nLintFramework/Rules/KeyValueFormatSpecifierCountRule.swift
+++ b/Sources/L10nLintFramework/Rules/KeyValueFormatSpecifierCountRule.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+struct KeyValueFormatSpecifierCountRule: Rule {
+    static let description: RuleDescription = .init(identifier: "key_value_format_specifier_count", name: "Key Value Format Specifier Count", description: "Format specifier count should be same between key and value")
+
+    init() {}
+
+    func validate(baseProject: LocalizedProject, project: LocalizedProject) throws -> [StyleViolation] {
+        let keyValueRegex = try NSRegularExpression(pattern: #"^ *"(?<key>.*)" *= *"(?<value>.*)" *; *$"#, options: .anchorsMatchLines)
+        let formatSpecifierRegex = try NSRegularExpression(pattern: #"%[0-9]*(?<type>[@dDuUxXoOfFeEgGcCsSpaAhlqLztj]+)"#)
+
+        return keyValueRegex.matches(in: project.stringsFile.contents).compactMap { result in
+            let nsStringContents = project.stringsFile.contents as NSString
+            let keyString = nsStringContents.substring(with: result.range(withName: "key"))
+            let valueString = nsStringContents.substring(with: result.range(withName: "value"))
+            let keyFormatSpecifierCounts: [String: Int] = formatSpecifierRegex.matches(in: keyString)
+                .reduce(into: [:]) { result, match in
+                    let type = (keyString as NSString).substring(with: match.range(withName: "type"))
+                    result[type] = (result[type] ?? 0) + 1
+                }
+            let valueFormatSpecifierCounts: [String: Int] = formatSpecifierRegex.matches(in: valueString)
+                .reduce(into: [:]) { result, match in
+                    let type = (valueString as NSString).substring(with: match.range(withName: "type"))
+                    result[type] = (result[type] ?? 0) + 1
+                }
+
+            if Set(keyFormatSpecifierCounts.keys) != Set(valueFormatSpecifierCounts.keys) {
+                return StyleViolation(
+                    ruleDescription: Self.description,
+                    severity: .warning,
+                    location: Location(file: project.stringsFile, characterOffset: result.range.location)
+                )
+            }
+
+            if let _ = keyFormatSpecifierCounts.first(where: { valueFormatSpecifierCounts[$0.key] != $0.value }) {
+                return StyleViolation(
+                    ruleDescription: Self.description,
+                    severity: .warning,
+                    location: Location(file: project.stringsFile, characterOffset: result.range.location)
+                )
+            }
+            
+            return nil
+        }
+    }
+}

--- a/Tests/L10nLintFrameworkTests/Resources/Fixtures/Localizables9/Base.lproj/Localizable.strings
+++ b/Tests/L10nLintFrameworkTests/Resources/Fixtures/Localizables9/Base.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"key1_%lld" = "value %lld";
+"key2_%d" = "value %d";
+"key3_%lld" = "value %d";
+"key4_%d" = "value %lld";
+"key5_%@_%lld" = "value %@ %lld";
+"key6_%@_%@" = "value %2@ %1@";
+"key7_%@_%lld_%lld" = "value %@ %lld %lld";
+"key8" = "value %@";
+"key9_%@" = "value %2@ %1@";
+"key10_%lld" = "value %@ %lld";

--- a/Tests/L10nLintFrameworkTests/RulesTests.swift
+++ b/Tests/L10nLintFrameworkTests/RulesTests.swift
@@ -166,6 +166,38 @@ final class RulesTests: XCTestCase {
             ]
         )
     }
+
+    func testIntegerFormatSpecifierRule() throws {
+        let baseProject = try TestHelper.localizedProjects(fixtureName: "Localizables9")
+            .first(where: { $0.name == "Base" })!
+
+        let violations = try IntegerFormatSpecifierRule().validate(baseProject: baseProject, project: baseProject)
+        XCTAssertEqual(
+            violations.map(\.location.point),
+            [
+                LocationPoint(line: 2, character: 20),
+                LocationPoint(line: 3, character: 22),
+                LocationPoint(line: 4, character: 7)
+            ]
+        )
+    }
+
+    func testKeyValueFormatSpecifierCountRule() throws {
+        let baseProject = try TestHelper.localizedProjects(fixtureName: "Localizables9")
+            .first(where: { $0.name == "Base" })!
+
+        let violations = try KeyValueFormatSpecifierCountRule().validate(baseProject: baseProject, project: baseProject)
+        XCTAssertEqual(
+            violations.map(\.location.point),
+            [
+                LocationPoint(line: 3, character: 1),
+                LocationPoint(line: 4, character: 1),
+                LocationPoint(line: 8, character: 1),
+                LocationPoint(line: 9, character: 1),
+                LocationPoint(line: 10, character: 1)
+            ]
+        )
+    }
 }
 
 extension Location {


### PR DESCRIPTION
- Adds rule to should be '%lld' instead of '%d' as integer format specifier.
- Adds rule to should be same number of format specifiers between key and value.